### PR TITLE
Fixes for Julia v0.5, fix numerical issue and take probability into account in Benders

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ An example of the StructJuMP.jl package reads:
 using StructJuMP
 
 numScen = 2
-m = StructuredModel(numScen)
+m = StructuredModel(num_scenarios=numScen)
 
 @defVar(m, 0 <= x <= 1)
 @defVar(m, 0 <= y <= 1)

--- a/src/BendersBridge.jl
+++ b/src/BendersBridge.jl
@@ -248,7 +248,7 @@ function BendersBridge(m::Model, master_solver, sub_solver)
 
     for i = 1:length(m.ext[:Stochastic].children)
         (c,A,B,b,var_cones, constr_cones, v) = conicconstraintdata(m.ext[:Stochastic].children[i])
-        push!(c_all, c)
+        push!(c_all, getprobability(m)[i] * c)
         push!(A_all, A)
         push!(B_all, B)
         push!(b_all, b)

--- a/src/StructJuMP.jl
+++ b/src/StructJuMP.jl
@@ -7,7 +7,7 @@ import MathProgBase.MathProgSolverInterface
 import ReverseDiffSparse
 
 export StructuredModel, getStructure, getparent, getchildren, getProcIdxSet,
-       num_scenarios, @second_stage
+       num_scenarios, @second_stage, getprobability
 
 # ---------------
 # StructureData

--- a/test/benderstest.jl
+++ b/test/benderstest.jl
@@ -11,7 +11,7 @@ socp_solver = ECOS.ECOSSolver()
 
 facts("[Benders] Empty scenario test") do
 
-    m = StructuredModel(0)
+    m = StructuredModel(num_scenarios=0)
     @defVar(m, x, Int)
     @addConstraint(m, x <= 4)
     @setObjective(m, :Min, -5*x)
@@ -26,7 +26,7 @@ end
 facts("[Benders] Infeasible problem test") do
 
     numScen = 1
-    m = StructuredModel(numScen)
+    m = StructuredModel(num_scenarios=numScen)
 
     @defVar(m, x, Int)
 
@@ -49,7 +49,7 @@ end
 facts("[Benders] Infeasibility cut execution test #1") do
 
     numScen = 1
-    m = StructuredModel(numScen)
+    m = StructuredModel(num_scenarios=numScen)
 
     @defVar(m, x, Int)
 
@@ -73,7 +73,7 @@ end
 facts("[Benders] Optimality cut execution test #1") do
 
     numScen = 1
-    m = StructuredModel(numScen)
+    m = StructuredModel(num_scenarios=numScen)
 
     @defVar(m, x, Int)
 


### PR DESCRIPTION
I have tried StructJuMP on an example of my own using Julia v0.5.
The first issue I had is that in the tests and README, the instantiation of a structured model is missing the `num_scenarios` keyword.
Then I had to fix a few thinks for Julia v0.5 and take the probability into account in Benders.
I still had a strange issues but I figured out it was due to infeasibility ray that were too large so I added a scaling factor.

About the probabilities, it might be better to multiply the theta with them instead of the c_i. I choose the c_i so that I do not have to add any argument to Benders_pmap