### PR TITLE
Pull request/ef94d0ee

### DIFF
--- a/src/Benders_pmap.jl
+++ b/src/Benders_pmap.jl
@@ -120,7 +120,7 @@ function addCuttingPlanes(master_model, num_scen, A_all, b_all, output, x, θ, s
             # We scale it to avoid this issue
             scaling = abs(rhs)
             if scaling == 0
-              scaling = max(coef)
+              scaling = maximum(coef)
             end
             @addConstraint(master_model, dot(coef/scaling, x) <= sign(rhs))
             cut_added = true


### PR DESCRIPTION
The first commit is a small fix for the previous pull request.
The second commit is more important.
For the [SDDP package](https://github.com/blegat/StochasticDualDynamicProgramming.jl), I allow to either supply the data using a low level interface using matrices or to use StructJuMP.
The issue is that usually, the number of stages is like 48 with 3 scenarios at each stages which makes 3^48 possible realization of the uncertainty. However the uncertainty at each stages are usually independant which is called "serial independance" so instead of having to do

```
for s1 in 1:3
  for s2 in 1:3
    for s3 in 1:3
      ...
        for s48 in 1:3
```

we could do something like

```
for stage in 1:48
  for s in 1:3
```
where basically, each of the 3 scenarios has the same 3 children which are the 3 scenarios at the next stage.

To add this functionality to `StructJuMP`, I see 2 options.

* either tell the 2nd and 3rd scenarios that they have the same children than the first scenario and tell each of the 3 scenarios of the next stage that their parent is the 1st scenario (this is the solution I have implemented in the second commit). The variables of the 1st scenarios are used by the children.
* or tell each of the 3 scenarios of the next stage that they have 3 parents and give a vector containing the parents. The problem with this solution is as follows : "The variables of which parent are going to be used to model the children ?", we can say that it is the variables of the first one but this seems a bit hacky.

What do you think ?