### PR TITLE
In synch with StructJuMPSolverInterface

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,18 +2,26 @@
 The StructJuMP package provides a parallel algebraic modeling framework for block structured optimization models in Julia. StructJuMP, originally known as StochJuMP, is tailored to two-stage stochastic optimization problems and uses MPI to enable a parallel, distributed memory instantiation of the problem. StructJuMP.jl is an extension of the [JuMP.jl](https://github.com/JuliaOpt/JuMP.jl) package, which is as fast as [AMPL](http://ampl.com) and faster than any other modeling tools such as [GAMS](http://www.gams.com) and [Pyomo](http://www.pyomo.org) (see [this](http://arxiv.org/pdf/1312.1431.pdf)).
 
 
-##Nonlinear solvers for StructJuMP
-Problems modeled in StructJuMP models can be solved in parallel using [PIPS-NLP](https://github.com/Argonne-National-Laboratory/PIPS) parallel optimization solver. In addition, StructJuMP models can be solved (in serial only) using [Ipopt](https://projects.coin-or.org/Ipopt). The solver interface and glue code  for PIPS-NLP and Ipopt are located at [StructJuMPSolverInterface](https://github.com/Argonne-National-Laboratory/StructJuMPSolverInterface.jl). 
+##Nonlinear solvers
+
+Problems modeled in StructJuMP models can be solved in parallel using the [PIPS-NLP](https://github.com/Argonne-National-Laboratory/PIPS) parallel optimization solver. In addition, StructJuMP models can be solved (in serial only) using [Ipopt](https://projects.coin-or.org/Ipopt). The solver interface and glue code  for PIPS-NLP and Ipopt are located at [StructJuMPSolverInterface](https://github.com/Argonne-National-Laboratory/StructJuMPSolverInterface.jl). 
 
 
 ##Installation
-1. Install and build PIPS-NLP solver located [installation instruction](https://github.com/Argonne-National-Laboratory/PIPS). Then set the environment variables `PIPS_NLP_PAR_SHARED_LIB` and `PIPS_NLP_SHARED_LIB` to the location of the PIPS-NLP parallel and serial shared (.so|.dylib) Libraries correspondingly. Note that the shared libraries are named `libparpipsnlp.so|.dylib` and `libpipsnlp.so|.dylib`.
 
-2. Install Ipopt solver, if not already installed:
+Prior its installation, StructJuMP requires both PIPS-NLP and Ipopt solvers to be installed. 
+
+1. Install and build the PIPS-NLP solver using the installation instructions found [here](https://github.com/Argonne-National-Laboratory/PIPS). Then set the environment variables `PIPS_NLP_PAR_SHARED_LIB` and `PIPS_NLP_SHARED_LIB` to the location of the PIPS-NLP parallel and serial shared (.so|.dylib) libraries. Note that these shared libraries are named `libparpipsnlp.so|.dylib` and `libpipsnlp.so|.dylib`.
+
+2. Install the Ipopt solver, if not already installed:
 
  `julia> Pkg.add("Ipopt")`
 
-2. Install StructJuMPSolverInterface:
+3. Install StructJuMP (this package):
+
+ `julia> Pkg.clone("https://github.com/joehuchette/StructJuMP.jl")
+
+4. Install StructJuMPSolverInterface:
  
  `julia> Pkg.clone("https://github.com/Argonne-National-Laboratory/StructJuMPSolverInterface.jl")`
 
@@ -36,7 +44,7 @@ for i in 1:numScen
     @NLobjective(bl, Min, y[1]^2 + y[2]^2 + y[1]*y[2])
 end
 ```
-The above example builds a two level structured model `m` with 2 scenarios. Then this model can be solved by calling `solve` function and specifying a solver that implements the StructJuMPSolverInterface. 
+The above example builds a two level structured model `m` with 2 scenarios. The model can be solved by calling solve function with a solver that implements the StructJuMPSolverInterface. 
 ```julia
 solve(m, solver="PipsNlp") #solving using parallel PIPS-NLP solver
 solve(m, solver="PipsNlpSerial") #solving using serial PIPS-NLP solver, mostly for debug and maintenance purpose

--- a/README.md
+++ b/README.md
@@ -1,7 +1,24 @@
-# StructJuMP.jl
-The StructJuMP.jl package provides a scalable algebraic modeling framework for block structured optimization models in Julia. StructJuMP was originally known as StochJuMP, and tailored specifically towards two-stage stochastic optimization problems. StructJuMP.jl is an extension of the [JuMP.jl](https://github.com/JuliaOpt/JuMP.jl) package, which is as fast as [AMPL](http://ampl.com) and faster than any other modeling tools such as [GAMS](http://www.gams.com) and [Pyomo](http://www.pyomo.org) (see [this](http://arxiv.org/pdf/1312.1431.pdf)).
+# StructJuMP
+The StructJuMP package provides a parallel algebraic modeling framework for block structured optimization models in Julia. StructJuMP, originally known as StochJuMP, is tailored to two-stage stochastic optimization problems and uses MPI to enable a parallel, distributed memory instantiation of the problem. StructJuMP.jl is an extension of the [JuMP.jl](https://github.com/JuliaOpt/JuMP.jl) package, which is as fast as [AMPL](http://ampl.com) and faster than any other modeling tools such as [GAMS](http://www.gams.com) and [Pyomo](http://www.pyomo.org) (see [this](http://arxiv.org/pdf/1312.1431.pdf)).
 
-An example of the StructJuMP.jl package reads:
+
+##Nonlinear solvers for StructJuMP
+Problems modeled in StructJuMP models can be solved in parallel using [PIPS-NLP](https://github.com/Argonne-National-Laboratory/PIPS) parallel optimization solver. In addition, StructJuMP models can be solved (in serial only) using [Ipopt](https://projects.coin-or.org/Ipopt). The solver interface and glue code  for PIPS-NLP and Ipopt are located at [StructJuMPSolverInterface](https://github.com/Argonne-National-Laboratory/StructJuMPSolverInterface.jl). 
+
+
+##Installation
+1. Install and build PIPS-NLP solver located [installation instruction](https://github.com/Argonne-National-Laboratory/PIPS). Then set the environment variables `PIPS_NLP_PAR_SHARED_LIB` and `PIPS_NLP_SHARED_LIB` to the location of the PIPS-NLP parallel and serial shared (.so|.dylib) Libraries correspondingly. Note that the shared libraries are named `libparpipsnlp.so|.dylib` and `libpipsnlp.so|.dylib`.
+
+2. Install Ipopt solver, if not already installed:
+
+ `julia> Pkg.add("Ipopt")`
+
+2. Install StructJuMPSolverInterface:
+ 
+ `julia> Pkg.clone("https://github.com/Argonne-National-Laboratory/StructJuMPSolverInterface.jl")`
+
+
+##An example
 ```julia
 using StructJuMP, JuMP
 
@@ -11,20 +28,24 @@ m = StructuredModel(num_scenarios=numScen)
 @NLconstraint(m, x[1] + x[2] == 100)
 @NLobjective(m, Min, x[1]^2 + x[2]^2 + x[1]*x[2])
 
-for i in 1:scen
-    bl = StructuredModel(parent=m)
+for i in 1:numScen
+    bl = StructuredModel(parent=m, id=i)
     @variable(bl, y[1:2])
     @NLconstraint(bl, x[1] + y[1]+y[2] ≥  0)
     @NLconstraint(bl, x[2] + y[1]+y[2] ≤ 50)
     @NLobjective(bl, Min, y[1]^2 + y[2]^2 + y[1]*y[2])
 end
 ```
-
-## Solvers for StructJuMP
-The StructJuMP model can be solved by either PIPS or DSP. [PIPS](https://github.com/Argonne-National-Laboratory/PIPS/) is an open-source parallel interior point solver for stochastic convex and nonconvex continuous programs. [DSP](https://github.com/kibaekkim/DSP) is a open-source package of the parallel decomposition methods for stochastic mixed-integer programs. The Julia interface for PIPS and DSP are also available in [PIPS.jl](https://github.com/kibaekkim/PIPS.jl) and [DSPsolver.jl](https://github.com/kibaekkim/DSPsolver.jl), respectively.
-
-##Nonlinear solvers for StructJuMP
-The nonlinear StructJuMP models can be solved by either parallel or serial optimizaton solvers, such as PIPS-NLP and Ipopt respectively. [PIPS-NLP](https://github.com/Argonne-National-Laboratory/PIPS) is an extension to PIPS that parallelizes the solving algorithm for nonlinear programming problems using *Schur complement* approach. [Ipopt](https://projects.coin-or.org/Ipopt) is an Interior point optimization solver for finding local solution of large-scale nonlinear optimization problems. In the later case, modeller can still take advantage of StructJuMP to model the problem using its structure, and to solve the problem using more matured (or robust) solvers. The corresponding solver interface implementations for PIPS-NLP and Ipopt are located at [StructJuMPSolverInterface](https://github.com/fqiang/StructJuMPSolverInterface.jl). 
+The above example builds a two level structured model `m` with 2 scenarios. Then this model can be solved by calling `solve` function and specifying a solver that implements the StructJuMPSolverInterface. 
+```julia
+solve(m, solver="PipsNlp") #solving using parallel PIPS-NLP solver
+solve(m, solver="PipsNlpSerial") #solving using serial PIPS-NLP solver, mostly for debug and maintenance purpose
+solve(m, solver="Ipopt") #solving using (serial) Ipopt solver
+```
 
 ## Known Limitation
-* If a constraint declared at the sub-problem uses variable from the parent level, it has to be add using @addNLConstraint (instead of @addConstraint). 
+* If a constraint declared at the sub-problem uses variable from the parent level, it has to be add using @NLconstraint (instead of @constraint). 
+
+
+## Acknowledgements
+StructJuMP has been developed under the financial support of Department of Energy (DOE), Office of Advanced Scientific Computing Research, Office of Electricity Delivery and Energy Reliability, and Grid Modernization Laboratory Consortium (GMLC) (PIs: Cosmin G. Petra and Mihai Anitescu, Argonne National Laboratory).

--- a/src/StructJuMP.jl
+++ b/src/StructJuMP.jl
@@ -5,21 +5,22 @@ import JuMP # To reexport, should be using (not import)
 import MathProgBase
 import MathProgBase.MathProgSolverInterface
 import ReverseDiffSparse
+import StructJuMPSolverInterface
 
 export StructuredModel, getStructure, getparent, getchildren, getProcIdxSet,
        num_scenarios, @second_stage, getprobability, getMyRank
-
+       
 # ---------------
 # StructureData
 # ---------------
 
 type StructureData
     probability::Vector{Float64}
-    children::Vector{JuMP.Model}
+    children::Dict{Int,JuMP.Model}
     parent
     num_scen::Int
-    # othervars::Vector{JuMP.Variable}
     othermap::Dict{JuMP.Variable,JuMP.Variable}
+    comm::MPI.Comm
 end
 
 default_probability(m::JuMP.Model) = 1 / num_scenarios(m)
@@ -30,12 +31,20 @@ default_probability(::Void) = 1.0
 # ---------------
 
 # Constructor with the number of scenarios
-function StructuredModel(;solver=JuMP.UnsetSolver(), parent=nothing, same_children_as=nothing, num_scenarios::Int=0, prob::Float64=default_probability(parent))
+function StructuredModel(;solver=JuMP.UnsetSolver(), parent=nothing, same_children_as=nothing, id=0, num_scenarios::Int=0, prob::Float64=default_probability(parent))
     m = JuMP.Model(solver=solver)
     if parent !== nothing
+        @assert id != 0 
         stoch = getStructure(parent)
-        push!(stoch.children, m)
+        stoch.children[id] = m
         push!(stoch.probability, prob)
+        comm = stoch.comm
+        @assert comm == MPI.COMM_WORLD
+    else
+        id = 0
+        MPI.Init()  #finalized in the StructJuMPSolverInterface.sj_solve
+        comm = MPI.COMM_WORLD
+        JuMP.setsolvehook(m,StructJuMPSolverInterface.sj_solve)
     end
     if same_children_as !== nothing
       if !isa(same_children_as, JuMP.Model) || !haskey(same_children_as.ext, :Stochastic)
@@ -45,9 +54,9 @@ function StructuredModel(;solver=JuMP.UnsetSolver(), parent=nothing, same_childr
       children = same_children_as.ext[:Stochastic].children
     else
       probability = Float64[]
-      children = JuMP.Model[]
+      children = Dict{Int, JuMP.Model}()
     end
-    m.ext[:Stochastic] = StructureData(probability, children, parent, num_scenarios, Dict{JuMP.Variable,JuMP.Variable}())
+    m.ext[:Stochastic] = StructureData(probability, children, parent, num_scenarios, Dict{JuMP.Variable,JuMP.Variable}(), comm)
     m
 end
 


### PR DESCRIPTION
This PR updates StructJuMP to work with StructJuMPSolverInterface.

1. It introduces an id field for each of the children node. 
2. It hooks up the StructJuMP model with JuMP's solve function.
3. Updates the README file with installation instructions and NLP solvers information.
4. Code works independently of whether the user initializes MPI.